### PR TITLE
Installation Fix Proposed + typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Sci Corpus
 
 Scientific corpus manager.
 
-Dependences:
+Dependencies:
 
 * Python 2.7 >
 * PySide 1.2 >
@@ -13,15 +13,15 @@ Dependences:
 Installing
 ==========
 
-To install run into sci-corpus folder this following command:
+To install, browse to your sci-corpus folder and run this following command:
 
 # python setup.py install
 
-It will install the dependencies.
+It will automatically install all dependencies.
 
 For Windows users, you need to use CMD as administrator and run inside the sci-corpus the following commands:
 
 # c:\Python27\python.exe setup.py install
 
-But eventually it not works because of its dependencies from Visual Studio for compiler. 
+However, it eventually doesn't work because of its dependencies from Visual Studio for compiler .
 So download the binaries from site.

--- a/README.rst
+++ b/README.rst
@@ -14,14 +14,36 @@ Installing
 ==========
 
 To install, browse to your sci-corpus folder and run this following command:
-
-# python setup.py install
+::
+      # python setup.py install
 
 It will automatically install all dependencies.
 
 For Windows users, you need to use CMD as administrator and run inside the sci-corpus the following commands:
-
-# c:\Python27\python.exe setup.py install
+::
+      # c:\Python27\python.exe setup.py install
 
 However, it eventually doesn't work because of its dependencies from Visual Studio for compiler .
 So download the binaries from site.
+
+
+* **Tip: qmake not found Error**
+
+If during the installation of PySide you see an error stating that qmake was not found, this may be related to a long-standing change in nomenclature of qmake binary file in Fedora systems. Fortunately, there's a very simple solution.
+In the near future, this should be incorporated automatically in the installation (using --qmake flag).
+
+1. You'll first need to actually locate it:
+::
+      $ locate qmake | grep bin
+
+2. One of the solutions you'll find is something very similar to
+::
+      /usr/bin/qmake-qt4
+
+Use this path (or whatever you've found instead) in the next item.
+
+3. Create a symbolic link (as root!):
+::
+      # ln -s /usr/bin/qmake-qt4 /usr/bin/qmake
+
+Then, retry the installation process and everything should work properly!

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,8 @@ setup(name='Sci Corpus',
       author_email='daniel.pizetta@usp.br, jose.ronqui@usp.br, tiago.campos@usp.br',
       download_url='https://github.com/zericardo182/sci-corpus',
       classifiers=classifiers, 
-      dependency_links=[],
+      dependency_links=[
+-      dependency_links=['http://pypi.python.org/pypi/reportlab', 'http://pypi.python.org/pypi/PySide','http://pypi.python.org/pypi/lxml'],
       packages=['sci_corpus','sci_corpus.ui'],
       install_requires=['reportlab>=3.0', 'lxml>=3.0', 'PySide>=1.2'],
       scripts=['scicorpus.py'])

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ def dependancyChecks():
     print "Checking PySide Library ..."
     try:
         import PySide
+        import PySide.QtCore
     except ImportError as msg:
         print 'Sorry, please install PySide 1.1.0 or higher.'
         print 'You can find here: <http://qt-project.org/wiki/PySide>'
@@ -109,7 +110,7 @@ setup(name='Sci Corpus',
       author_email='daniel.pizetta@usp.br, jose.ronqui@usp.br, tiago.campos@usp.br',
       download_url='https://github.com/zericardo182/sci-corpus',
       classifiers=classifiers, 
-      dependency_links=['http://pypi.python.org/pypi/reportlab', 'http://pypi.python.org/pypi/PySide','http://pypi.python.org/pypi/lxml'],
+      dependency_links=[],
       packages=['sci_corpus','sci_corpus.ui'],
       install_requires=['reportlab>=3.0', 'lxml>=3.0', 'PySide>=1.2'],
       scripts=['scicorpus.py'])


### PR DESCRIPTION
There's a bug in the installation of PySide in Fedora systems. That's due to a long standing (since F15) change in the name of qmake binary file. I'm describing the solution in the ReadMe file, however the ideal solution would be to incorporate it on the install setup. This is not straightforward, but can be accomplished by using --qmake flag in PySide installation (checked!). Another solution is to automatically create the symbolic link.
